### PR TITLE
Change 'overwrite' variable

### DIFF
--- a/main_abrbaby_ERP.m
+++ b/main_abrbaby_ERP.m
@@ -11,7 +11,7 @@ name = 'EH';
 % Load path and start Matlab : returns ALLEEG (EEGLAB structure)
 ALLEEG = prep_and_start_environement(eeglab_path, biosig_installer_path, erplab_path) ;
 
-% ------------------- Preprocess : filter, reref, epoch, set chan positions
+%% ------------------- Preprocess : filter, reref, epoch, set chan positions
 OPTIONS.indir = indir ;
 OPTIONS.hp = 1; % high-pass (Hz) (APICE)
 OPTIONS.lp = 30; % low-pass (Hz) (APICE) 

--- a/main_abrbaby_ERP.m
+++ b/main_abrbaby_ERP.m
@@ -2,8 +2,8 @@
 
 %% ------------------- Set environment 
 % Variables to enter manually before running the code
-% name = 'EH';
-name = 'ASD';
+name = 'EH';
+%name = 'ASD';
 
 % This function sets custom path (either for Estelle or AnneSo)
 [eeglab_path, biosig_installer_path, erplab_path,indir,plot_dir,~] = get_custom_path(name);
@@ -11,17 +11,18 @@ name = 'ASD';
 % Load path and start Matlab : returns ALLEEG (EEGLAB structure)
 ALLEEG = prep_and_start_environement(eeglab_path, biosig_installer_path, erplab_path) ;
 
-%% ------------------- Preprocess : filter, reref, epoch, set chan positions
+% ------------------- Preprocess : filter, reref, epoch, set chan positions
 OPTIONS.indir = indir ;
 OPTIONS.hp = 1; % high-pass (Hz) (APICE)
 OPTIONS.lp = 30; % low-pass (Hz) (APICE) 
 OPTIONS.mastos = {'Lmon','Rmon','MASTOG','MASTOD'}; OPTIONS.trig = {'Erg1'}; % Ref and trigger channels 
-OPTIONS.baseline = [-99, 0] ; OPTIONS.win_of_interest = [-0.1, 0.5] ; 
+%OPTIONS.baseline = [-99, 0] ; OPTIONS.win_of_interest = [-0.1, 0.5] ; 
+OPTIONS.baseline = [-199, 0] ; OPTIONS.win_of_interest = [-0.2, 0.5] ; 
 OPTIONS.conditions = {'STD','DEV1','DEV2'} ; 
 OPTIONS.eeg_elec = 1:16 ; 
 OPTIONS.chan_dir = fullfile(eeglab_path,'plugins/dipfit/standard_BEM/elec/standard_1005.elc') ; 
-OPTIONS.overwrite = 1 ; % this option allow to overwrite (=1) or not (=0) 
-[preproc_filenames] = reref_filter_epoch_erp(ALLEEG, OPTIONS);
+overwrite = 0 ; % this option allow to overwrite (=1) or not (=0) 
+[preproc_filenames] = reref_filter_epoch_erp(ALLEEG, OPTIONS, overwrite);
 
 %% ------------------- Preprocess : Reject BAD trials 
 rej_low = -150; %150 infants; 120 adults

--- a/reref_filter_epoch_erp.m
+++ b/reref_filter_epoch_erp.m
@@ -1,9 +1,9 @@
-function [out_filenames] = reref_filter_epoch_erp(ALLEEG, OPTIONS)
+function [out_filenames] = reref_filter_epoch_erp(ALLEEG, OPTIONS, overwrite)
 % ERPs sanity check script - 
 % Estelle Herve, A.-Sophie Dubarry - 2022 - %80PRIME Project
 
 % Get OPTIONS
-[indir, hp, lp, mastos, trig, eeg_elec, baseline, win_of_interest, conditions, chan_dir, overwrite]= get_OPTIONS(OPTIONS) ;
+[indir, hp, lp, mastos, trig, eeg_elec, baseline, win_of_interest, conditions, chan_dir]= get_OPTIONS(OPTIONS) ;
 
 % Reads all folders that are in indir 
 d = dir(indir); 
@@ -31,7 +31,7 @@ for jj=1:length(subjects)
     [does_exist, count] = check_exist_set_params(filename, subjects{jj},OPTIONS) ; 
 
     if does_exist && overwrite == 0; continue; end
-        
+
     % Creates resulting filename
     out_filenames{jj} = fullfile(indir,subjects{jj}, strcat(filename,'_reref_filtered_epoched_RFE',num2str(count),'.set')) ; 
 
@@ -116,7 +116,7 @@ end
 %--------------------------------------------------------------
 % FUNCTION that get OPTIONS values
 %--------------------------------------------------------------
-function [indir, hp, lp, mastos, trig, eeg_elec, baseline, win_of_interest, conditions, chan_dir, overwrite]= get_OPTIONS(OPTIONS) 
+function [indir, hp, lp, mastos, trig, eeg_elec, baseline, win_of_interest, conditions, chan_dir]= get_OPTIONS(OPTIONS) 
 
 indir = OPTIONS.indir ;
 hp = OPTIONS.hp;
@@ -128,7 +128,6 @@ baseline = OPTIONS.baseline;
 win_of_interest = OPTIONS.win_of_interest;
 conditions = OPTIONS.conditions;
 chan_dir = OPTIONS.chan_dir;
-overwrite = OPTIONS.overwrite;
 
 end
 


### PR DESCRIPTION
'Overwrite' variable has been removed from the OPTION structure so it does not appear in the history_rfe. Allows new participants to be preprocessed with the same parameters as the previous ones without considering the 'overwrite' parameter (otherwise it creates a new .set for old participants if 'overwrite' is different).