### PR TITLE
Compute once (skip if existing processed data)

### DIFF
--- a/main_abrbaby_ERP.m
+++ b/main_abrbaby_ERP.m
@@ -1,9 +1,10 @@
-
+% ERPs Pipeline analysisfor ABRBABY
+% Estelle Herve, A.-Sophie Dubarry - 2023 - %80PRIME Project
 
 %% ------------------- Set environment 
 % Variables to enter manually before running the code
-name = 'EH';
-%name = 'ASD';
+% name = 'EH';
+name = 'ASD';
 
 % This function sets custom path (either for Estelle or AnneSo)
 [eeglab_path, biosig_installer_path, erplab_path,indir,plot_dir,~] = get_custom_path(name);
@@ -13,21 +14,30 @@ ALLEEG = prep_and_start_environement(eeglab_path, biosig_installer_path, erplab_
 
 %% ------------------- Preprocess : filter, reref, epoch, set chan positions
 OPTIONS.indir = indir ;
-OPTIONS.hp = 1; % high-pass (Hz) (APICE)
-OPTIONS.lp = 30; % low-pass (Hz) (APICE) 
-OPTIONS.mastos = {'Lmon','Rmon','MASTOG','MASTOD'}; OPTIONS.trig = {'Erg1'}; % Ref and trigger channels 
-%OPTIONS.baseline = [-99, 0] ; OPTIONS.win_of_interest = [-0.1, 0.5] ; 
-OPTIONS.baseline = [-199, 0] ; OPTIONS.win_of_interest = [-0.2, 0.5] ; 
+OPTIONS.hp = 1;                                         % high-pass (Hz) (APICE)
+OPTIONS.lp = 30;                                        % low-pass (Hz) (APICE) 
+OPTIONS.mastos = {'Lmon','Rmon','MASTOG','MASTOD'}; 
+OPTIONS.trig = {'Erg1'};                                % Ref and trigger channels 
+%OPTIONS.baseline = [-99, 0] ; 
+%OPTIONS.win_of_interest = [-0.1, 0.5] ; 
+OPTIONS.baseline = [-199, 0] ; 
+OPTIONS.win_of_interest = [-0.2, 0.5] ; 
 OPTIONS.conditions = {'STD','DEV1','DEV2'} ; 
 OPTIONS.eeg_elec = 1:16 ; 
 OPTIONS.chan_dir = fullfile(eeglab_path,'plugins/dipfit/standard_BEM/elec/standard_1005.elc') ; 
-overwrite = 0 ; % this option allow to overwrite (=1) or not (=0) 
-[preproc_filenames] = reref_filter_epoch_erp(ALLEEG, OPTIONS, overwrite);
+
+% Test if this set of params exists and returns the files to process and
+% counter to use to name the saved files
+[flag_sub_to_create, count]= test_existance_of_params_in_db(OPTIONS); 
+
+% Reref filter epoch erp : only apply to subjects which were not already
+% computed with this set of parameters (as defined by flag_sub_to_create) ;
+[preproc_filenames] = reref_filter_epoch_erp(ALLEEG, OPTIONS,flag_sub_to_create, count);
 
 %% ------------------- Preprocess : Reject BAD trials 
-rej_low = -150; %150 infants; 120 adults
-rej_high = 150; %150 infants; 120 adults
-bloc = repelem(1:30,30) ; % creates a vector of [1 1 1 1 (30 times) 2 2 2 2 (30 times) etc. up to 30]
+rej_low = -150;             % 150 infants; 120 adults
+rej_high = 150;             % 150 infants; 120 adults
+bloc = repelem(1:30,30) ;   % creates a vector of [1 1 1 1 (30 times) 2 2 2 2 (30 times) etc. up to 30]
 
 % Reject bad trials and save new .set file
 select_and_save_trials_per_condition(ALLEEG, preproc_filenames, eeg_elec, win_of_interest, rej_low, rej_high, 'balanced') ; 
@@ -35,7 +45,6 @@ select_and_save_trials_per_condition(ALLEEG, preproc_filenames, eeg_elec, win_of
 
 % Write csv file directly into the subject dir
 [~] = reject_trials_produce_report(preproc_filenames, eeg_elec, bloc, win_of_interest, rej_low, rej_high,'') ; 
-
 
 %% ------------------- Display : 
 elec_subset = {'F3','Fz','F4';'C3','Cz','C4'};

--- a/reref_filter_epoch_erp.m
+++ b/reref_filter_epoch_erp.m
@@ -1,4 +1,4 @@
-function [out_filenames] = reref_filter_epoch_erp(ALLEEG, OPTIONS, overwrite)
+function [out_filenames] = reref_filter_epoch_erp(ALLEEG, OPTIONS, flag_sub_to_create, count)
 % ERPs sanity check script - 
 % Estelle Herve, A.-Sophie Dubarry - 2022 - %80PRIME Project
 
@@ -10,6 +10,12 @@ d = dir(indir);
 isub = [d(:).isdir]; % returns logical vector if is folder
 subjects = {d(isub).name}';
 subjects(ismember(subjects,{'.','..'})) = []; % Removes . and ..
+
+% Inititalize output parameter
+out_filenames = [] ; 
+
+% Only keeps subjects to process
+subjects = subjects(flag_sub_to_create) ; 
 
 %Loop through subjects
 for jj=1:length(subjects) 
@@ -23,21 +29,9 @@ for jj=1:length(subjects)
     fname= dir(fullfile(indir,subjects{jj},'*.bdf'));
     [~,filename,~] = fileparts(fname.name);    
 
-    % Verifier les fichiers existants (+suffix) 
-    % lire les variables history 
-    % verifier quelle sont differentes de celles demandé
-    % Si different +1     
-
-    [does_exist, count] = check_exist_set_params(filename, subjects{jj},OPTIONS) ; 
-
-    if does_exist && overwrite == 0; continue; end
-
     % Creates resulting filename
     out_filenames{jj} = fullfile(indir,subjects{jj}, strcat(filename,'_reref_filtered_epoched_RFE',num2str(count),'.set')) ; 
-
-    % Skip if subject rerefe filtered_epochs already exist and we don't
-    % want to overwrite
-        
+            
     % Select bdf file in the folder
     EEG = pop_biosig(fullfile(indir, subjects{jj}, fname.name));
 
@@ -73,9 +67,6 @@ for jj=1:length(subjects)
     [ALLEEG, EEG] = eeg_store(ALLEEG, EEG, CURRENTSET);
     EEG = eeg_checkset( EEG );
 
-%     %% SAVE DATASET BEFORE EPOCHING
-%     [ALLEEG, EEG, CURRENTSET] = pop_newset(ALLEEG, EEG, CURRENTSET, 'setname', strcat(filename,'_filtered'),'savenew', fullfile(indir,subjects{jj}, strcat(filename,'_filtered')),'gui','off');
-%     
     % Extract ALL conditions epochs
     EEG = pop_epoch(EEG, conditions, win_of_interest, 'newname', strcat(filename,'_ALL'), 'epochinfo', 'yes');
 

--- a/test_existance_of_params_in_db.m
+++ b/test_existance_of_params_in_db.m
@@ -1,0 +1,64 @@
+function [flag_sub_to_create, counter] = test_existance_of_params_in_db(OPTIONS)
+% ERPs sanity check script - 
+% Estelle Herve, A.-Sophie Dubarry - 2023 - %80PRIME Project
+
+% Reads all folders that are in indir 
+d = dir(OPTIONS.indir); 
+isub = [d(:).isdir]; % returns logical vector if is folder
+subjects = {d(isub).name}';
+subjects(ismember(subjects,{'.','..'})) = []; % Removes . and ..
+
+suffix = '*_reref_filtered_epoched_RFE*' ; 
+
+%Loop through subjects
+for jj=1:length(subjects) 
+
+    % Printout the id of the subject in console
+    fprintf(strcat(subjects{jj}, '...\n'));
+
+    [does_exist, count(jj)] = check_exist_set_params(subjects{jj}, suffix, OPTIONS) ; 
+    flag_sub_to_create(jj) = ~does_exist ; 
+      
+end
+
+% Here if count for file to process are not the same : error 
+if ~all(count(~flag_sub_to_create) == max(count))
+    error('Something wrong in the databse');
+else 
+    counter = max(count) ;
+end
+
+end
+
+%--------------------------------------------------------------
+% FUNCTION that check if that sets of param exist 
+%--------------------------------------------------------------
+function [does_exist, count] = check_exist_set_params(subject, suffix, OPTIONS)
+
+% Reads all folders that are in indir 
+d = dir(fullfile(OPTIONS.indir,subject,strcat(suffix,'.set'))); 
+
+% No file exists 
+if isempty(d) ; does_exist=0 ; count =1 ; return ; end
+
+for ff=1:length(d) 
+    
+    EEG = pop_loadset('filepath',fullfile(OPTIONS.indir,subject, d(ff).name),'loadmode','info') ;  
+    
+    % Check if the set of param correspond to the current file
+    if isequal(EEG.history_rfe,OPTIONS)
+        does_exist = 1 ; 
+        tmp = regexp(d(ff).name,'RFE\d*','Match');
+        tmp2 =  regexp(tmp,'\d*','Match');
+        count = str2num(cell2mat(tmp2{:})); 
+        return ; 
+    end
+    
+end
+
+% At this point the set of params does not exist and a new file needs to be
+% created (with a count increment)
+does_exist = 0 ; 
+count = length(d) +1;
+
+end


### PR DESCRIPTION
Modify code such that it now checks the existence of the resulting dataset (with the exact same set of processing parameters) before creating a new file.

If file exist : does not overwrite, but process other subjects. Get appropriate index to number the set of parameters consistently across participant folders.

This PR ONLY CONCERN 'ERP pipeline' for now.
